### PR TITLE
Fixed failUrl

### DIFF
--- a/src/main/kotlin/com/jakewharton/uispy/healthcheck.kt
+++ b/src/main/kotlin/com/jakewharton/uispy/healthcheck.kt
@@ -16,7 +16,7 @@ class HttpHealthCheck(
 	private val checkUrl: HttpUrl,
 ) : HealthCheck {
 	private val startUrl = checkUrl.newBuilder().addPathSegment("start").build()
-	private val failUrl = checkUrl.newBuilder().addPathSegment("start").build()
+	private val failUrl = checkUrl.newBuilder().addPathSegment("fail").build()
 
 	override suspend fun notifyStart() = notify(startUrl)
 	override suspend fun notifySuccess() = notify(checkUrl)


### PR DESCRIPTION
On documentation, it says you can use `/start` or `/fail`. It seems this is a typo unless intentional.

Ref: https://healthchecks.io/docs/